### PR TITLE
feat: Add release and build config

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -1,0 +1,68 @@
+name: Build and push container image
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'containers-mqtt-dumper-v*.*.*'
+
+env:
+  REGISTRY: ghcr.io
+  APP_SLUG: mqtt-dumper
+  IMAGE_NAME: ${{ github.repository_owner }}/${{ env.APP_SLUG }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            # match release-please manifest driven release tag format
+            # https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md
+            type=match,pattern=.*-v(\d+.\d+.\d+),group=1
+            type=match,pattern=.*-v(\d+.\d+),group=1
+            type=match,pattern=.*-v(\d+),group=1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+            type=gha
+          cache-to: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+            type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,20 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,3 @@
+{
+  "docker/mqtt_dumper": "0.1.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,9 @@
+{
+  "packages": {
+    "docker/mqtt_dumper": {
+      "release-type": "simple",
+      "package-name": "mqtt-dumper"
+    }
+  },
+  "plugins": ["python-workspace"]
+}


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow for building and pushing container images to GitHub Container Registry (ghcr.io).

The workflow is triggered on:
- Pushes to the `main` branch
- Tags matching the pattern `containers-mqtt-dumper-v*.*.*`

It performs the following steps:
- Extracts Docker metadata using docker/metadata-action
- Sets up QEMU for multi-architecture builds
- Sets up Docker Buildx
- Logs into the GitHub Container Registry
- Builds and pushes the Docker image using docker/build-push-action
- Supports building for linux/amd64 and linux/arm64 platforms
- Includes caching for faster builds
- Generates SBOM and provenance attestation

The image is tagged according to semantic versioning and git references.

This automated build process ensures that container images are built and published whenever changes are merged into the main branch or a new tag is created.