### PR TITLE
fix(container-build): set correct docker build context

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -52,6 +52,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
+          context: "{{defaultContext}}:docker/mqtt_dumper"
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
The docker build context was incorrectly set to the root directory.
This commit fixes the build context to the correct sub directory.