### PR TITLE
fix(docker): use environment variables for configuration

### DIFF
--- a/docker/mqtt_dumper/Dockerfile
+++ b/docker/mqtt_dumper/Dockerfile
@@ -4,6 +4,10 @@ FROM python:3.13-slim
 # Set working directory
 WORKDIR /app
 
+ENV TOPICS=""
+ENV LOG=INFO
+ENV OUTPUT_DIR=/app/data
+
 # Install only required system dependencies
 #RUN apt-get update && apt-get install -y --no-install-recommends \
 #    gcc \
@@ -17,4 +21,4 @@ COPY hfp_mqtt_data_dumper.py /app/hfp_mqtt_data_dumper.py
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Run the MQTT dumper script
-CMD ["python", "hfp_mqtt_data_dumper.py"]
+CMD ["python", "hfp_mqtt_data_dumper.py", "--output-dir", "$OUTPUT_DIR", "--log", "$LOG", "--topics", "$TOPICS"]

--- a/docker/mqtt_dumper/Dockerfile
+++ b/docker/mqtt_dumper/Dockerfile
@@ -10,8 +10,8 @@ WORKDIR /app
 #    && rm -rf /var/lib/apt/lists/*
 
 # Copy only the necessary files
-COPY ./docker/mqtt_dumper/requirements.txt /app/requirements.txt
-COPY ./docker/mqtt_dumper/hfp_mqtt_data_dumper.py /app/hfp_mqtt_data_dumper.py
+COPY requirements.txt /app/requirements.txt
+COPY hfp_mqtt_data_dumper.py /app/hfp_mqtt_data_dumper.py
 
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt

--- a/docker/mqtt_dumper/compose.yml
+++ b/docker/mqtt_dumper/compose.yml
@@ -19,29 +19,32 @@ services:
     container_name: hsl_dumper_2015
     volumes:
       - ../../data/raw/2015:/app/data
-    command: python hfp_mqtt_data_dumper.py --output-dir /app/data --log INFO --topics "/hfp/v2/journey/ongoing/+/tram/+/+/2015/#"
+    environment:
+      TOPICS: "/hfp/v2/journey/ongoing/+/tram/+/+/2015/#"
 
   hsl_dumper_koskelantie_50:
     <<: *mqtt_dumper_base
     container_name: hsl_dumper_koskelantie_50
     volumes:
       - ../../data/raw/koskelantie_50:/app/data
-    command: python hfp_mqtt_data_dumper.py --output-dir /app/data --log INFO --topics "/hfp/v2/journey/ongoing/+/bus/+/+/1057/+/+/+/+/+/60;24/29/15/#"
+    environment:
+      TOPICS: "/hfp/v2/journey/ongoing/+/bus/+/+/1057/+/+/+/+/+/60;24/29/15/#"
 
   hsl_dumper_65_71_79:
     <<: *mqtt_dumper_base
     container_name: hsl_dumper_65_71_79
     volumes:
       - ../../data/raw/65_71_79:/app/data
-    command: python hfp_mqtt_data_dumper.py --output-dir /app/data --log INFO --topics "/hfp/v2/journey/ongoing/+/bus/+/+/1071/#" "/hfp/v2/journey/ongoing/+/bus/+/+/1065/#" "/hfp/v2/journey/ongoing/+/bus/+/+/1079/#"
+    environment:
+      TOPICS: "/hfp/v2/journey/ongoing/+/bus/+/+/1079/#"
 
   hsl_dumper_all:
     <<: *mqtt_dumper_base
     container_name: hsl_dumper_all
     volumes:
       - ../../data/raw/all:/app/data
-    command: python hfp_mqtt_data_dumper.py --output-dir /app/data --log INFO --topics "/hfp/v2/journey/ongoing/#"
-
+    environment:
+      TOPICS: "/hfp/v2/journey/ongoing/#"
 
   # Example of additional dumper instance with different topics
   # mqtt_dumper_2:

--- a/docker/mqtt_dumper/compose.yml
+++ b/docker/mqtt_dumper/compose.yml
@@ -1,10 +1,10 @@
 services:
   mqtt_dumper_base: &mqtt_dumper_base
+    image: forumviriumhelsinki/containers-mqtt-dumper
+    build:
+      context: .
     profiles:
       - "donotstart"
-    build:
-      context: ../..
-      dockerfile: docker/mqtt_dumper/Dockerfile
     volumes:
       - ../../data/raw:/app/data
     restart: unless-stopped


### PR DESCRIPTION
This commit modifies the Dockerfile and compose.yml to utilize environment variables for configuring the MQTT dumper.

The Dockerfile now defines `TOPICS`, `LOG`, and `OUTPUT_DIR` as environment variables, providing more flexibility in configuring the dumper.

The compose.yml has been updated to remove the `command` directives, and use `environment` variables to define the TOPICS for each dumper instance. This aligns the configuration approach and makes it easier to manage.