### PR TITLE
refactor(ci): migrate renovate workflow to reusable caller

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -24,25 +24,10 @@ on:
           - debug
           - warn
 
-concurrency:
-  group: renovate
-  cancel-in-progress: false
-
 jobs:
   renovate:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      packages: read
-    steps:
-      - uses: actions/checkout@v6
-      - uses: renovatebot/github-action@v46.1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          configurationFile: renovate.json
-        env:
-          LOG_LEVEL: ${{ github.event.inputs.logLevel || 'info' }}
-          RENOVATE_DRY_RUN: ${{ github.event.inputs.dryRun || '' }}
-          RENOVATE_HOST_RULES: '[{"matchHost":"ghcr.io","hostType":"docker","username":"x-access-token","password":"${{ secrets.GITHUB_TOKEN }}"}]'
+    uses: ForumViriumHelsinki/.github/.github/workflows/reusable-renovate.yml@main
+    with:
+      log-level: ${{ inputs.logLevel || 'info' }}
+      dry-run: ${{ inputs.dryRun || 'false' }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace standalone Renovate workflow with reusable workflow caller
- Fixes missing `RENOVATE_REPOSITORIES` env var that caused Renovate to silently log "No repositories found"
- Delegates to `ForumViriumHelsinki/.github/.github/workflows/reusable-renovate.yml@main` with `secrets: inherit`

## Test plan
- [ ] Verify Renovate runs successfully on next scheduled trigger or manual dispatch
- [ ] Check logs show "Repository: ForumViriumHelsinki/{repo}" instead of "No repositories found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)